### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   backend:
     container_name: backend
-    entrypoint: sh -c "npm i && npm run start:dev"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run start:dev"
     environment:
       <<: *postgres-vars
       NODE_ENV: development
@@ -55,7 +55,7 @@ services:
 
   frontend:
     container_name: frontend
-    entrypoint: sh -c "npm ci && npm run dev"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run dev"
     environment:
       NODE_ENV: development
       PORT: 3000


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-415-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-415-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)